### PR TITLE
Fix type of variables $update_themes and $update_core to array()

### DIFF
--- a/check_wordpress
+++ b/check_wordpress
@@ -20,9 +20,9 @@ if($argc != 2) {
         print "usage: check_wordpress <path to wordpress>\n";
         exit(1);
 }
-$update_core    = false;
+$update_core    = array();
 $update_plugins = array();
-$update_themes  = false;
+$update_themes  = array();
 
 chdir($argv[1]);
 require_once('./wp-load.php');


### PR DESCRIPTION
I got the following Warnings
PHP Warning:  array_push() expects parameter 1 to be array, boolean given in /www/htdocs/check_wordpress on line 41
Warning: array_push() expects parameter 1 to be array, boolean given in /www/htdocs/check_wordpress on line 41

To avoid this I changed the variables $update_core and $update_themes to array();

